### PR TITLE
add curly braces to solve syntax errors

### DIFF
--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -15,6 +15,6 @@
   tags: ansible
 
 - name: Install Ansible packages
-  apt: name={{ item }} state=present update_cache=yes
-  with_items: ansible_packages
+  apt: name={{ item }} state=present update_cache=yes force=yes
+  with_items: "{{ ansible_packages }}"
   tags: ansible


### PR DESCRIPTION
@dwcramer 

I was getting this error before the change: No package matching 'ansible_packages' is available

And then I needed to do the force because of this: 
"stderr": "E: There are problems and -y was used without --force-yes\n", "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following packages were automatically installed and are no longer required:\n  linux-headers-3.16.0-67 linux-headers-3.16.0-67-generic\n  linux-image-3.16.0-67-generic python-support\nUse 'apt-get autoremove' to remove them.\nThe following held packages will be changed:\n  ansible\nThe following packages will be upgraded:\n  ansible\n1 upgraded, 0 newly installed, 0 to remove and 50 not upgraded.\nNeed to get 2024 kB of archives.\nAfter this operation, 6937 kB of additional disk space will be used.\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following packages were automatically installed and are no longer required:", "  linux-headers-3.16.0-67 linux-headers-3.16.0-67-generic", "  linux-image-3.16.0-67-generic python-support", "Use 'apt-get autoremove' to remove them.", "The following held packages will be changed:", "  ansible", "The following packages will be upgraded:", "  ansible", "1 upgraded, 0 newly installed, 0 to remove and 50 not upgraded.", "Need to get 2024 kB of archives.", "After this operation, 6937 kB of additional disk space will be used."]}